### PR TITLE
Fixed apply diff was leaving an empty item when deleting from an array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,11 @@ function apply(changes, target, modify) {
             if (i < len - 1) {
               ptr = ptr[prop];
             } else {
-              delete ptr[prop];
+              if (Array.isArray(ptr)) {
+                ptr.splice(parseInt(prop), 1);
+              } else {
+                delete ptr[prop];
+              }
             }
           });
         } else {

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,8 @@ describe('changeset', function () {
         tags: ['tag1', 'tag2', 'tag3'],
         scores: {
           tetris: 1000,
-          carmageddon: 3
+          carmageddon: 3,
+          someArray: ['one', 'two', 'three']
         }
       };
 
@@ -27,7 +28,8 @@ describe('changeset', function () {
         tags: ['tag1', 'tag4'],
         scores: {
           carmageddon: 3,
-          zelda: 3000
+          zelda: 3000,
+          someArray: ['one', 'three']
         },
         age: 37
       };
@@ -36,11 +38,14 @@ describe('changeset', function () {
       b.self = b;
 
       var changes = diff(a, b);
+
       expect(changes).to.deep.equal([
         { type: 'put', key: ['name'], value: 'Susan' },
         { type: 'put', key: ['number'], value: 43 },
         { type: 'put', key: ['tags', '1'], value: 'tag4' },
         { type: 'del', key: ['tags', '2'] },
+        { type: 'put', key: [ 'scores', 'someArray', '1' ], value: 'three' },
+        { type: 'del', key: [ 'scores', 'someArray', '2' ] },
         { type: 'del', key: ['scores', 'tetris'] },
         { type: 'put', key: ['scores', 'zelda'], value: 3000 },
         { type: 'put', key: ['self'], value: b },
@@ -103,7 +108,8 @@ describe('changeset', function () {
       tags: ['tag1', 'tag2', 'tag3'],
       scores: {
         tetris: 1000,
-        carmageddon: 3
+        carmageddon: 3,
+        someArray: ['one', 'two', 'three']
       }
     };
 
@@ -116,7 +122,8 @@ describe('changeset', function () {
       tags: ['tag1', 'tag4'],
       scores: {
         carmageddon: 3,
-        zelda: 3000
+        zelda: 3000,
+        someArray: ['one', 'three']
       },
       age: 37
     };
@@ -129,6 +136,7 @@ describe('changeset', function () {
 
     var changes = diff(a, b);
     var b_ = diff.apply(changes, a);
+    expect(b_.scores.someArray.length).to.equal(b.scores.someArray.length);
     expect(b_).to.deep.equals(b);
     expect(b).to.deep.equals(bClone); // Target did not change.
     done();
@@ -180,7 +188,8 @@ describe('changeset', function () {
           tags: ['tag1', 'tag2', 'tag3'],
           scores: {
             tetris: 1000,
-            carmageddon: 3
+            carmageddon: 3,
+            someArray: ['one', 'two', 'three']
           }
         };
 
@@ -193,7 +202,8 @@ describe('changeset', function () {
           tags: ['tag1', 'tag4'],
           scores: {
             carmageddon: 3,
-            zelda: 3000
+            zelda: 3000,
+            someArray: ['one', 'three']
           },
           age: 37
         };
@@ -203,6 +213,7 @@ describe('changeset', function () {
 
         var changes = diff(a, b);
         var b_ = diff.apply(changes, a, true);
+        expect(b_.scores.someArray.length).to.equal(b.scores.someArray.length);
         expect(b_).to.deep.equals(b);
         expect(b_).to.equal(a);
         done();


### PR DESCRIPTION
When applying a diff at an object, deleting an item from a nested array was not working as expected. It was just leaving an empty item at the specified index in the array rather that removing the item. That was caused because of the general `delete` operator that was used for all the types of the properties.

We now check if `ptr` is an array and removing the item at the array with the proper way.

Strangely , the error was not caught by the deep equality check of `chai` tests, even though the length of the two arrays was different.